### PR TITLE
Don't exit with error if selinux disabled

### DIFF
--- a/ash-linux/STIGbyID/cat3/files/V51379-helper.sh
+++ b/ash-linux/STIGbyID/cat3/files/V51379-helper.sh
@@ -27,8 +27,8 @@ esac
 
 if [ ${SETEXIT} -eq 1 ]
 then
-   printf "SELinux disabled: cannot check FS labeling\n"
-   exit ${SETEXIT}
+   printf "WARNING: SELinux disabled, cannot check FS labeling\n"
+   exit 0
 else
    FILELIST=`find /dev -print | xargs ls -dZ /dev 2> /dev/null | grep unlabeled_t | awk '{print $5}'`
    if [ "${FILELIST}" = "" ]


### PR DESCRIPTION
Print a big WARNING, but exit 0.
Fixes #57