### PR TITLE
'pkg.check_db' checks if hbss pkg is available

### DIFF
--- a/ash-linux/STIGbyID/cat1/V38666.sls
+++ b/ash-linux/STIGbyID/cat1/V38666.sls
@@ -45,6 +45,8 @@ cmd_V{{ stig_id }}-cleanChck:
 
 {%- else %}
 
+    {%- if salt['pkg.check_db'](MSFEpkg)[MSFEpkg]['found'] %}
+
 # If not installed, see if it's available in the Yum repos
 pkg_V{{ stig_id }}:
   pkg.installed:
@@ -55,6 +57,8 @@ notify_V{{ stig_id }}-installed:
     - name: 'echo "Installed HBSS package"'
     - onlyif:
       - 'test $(rpm -qa | grep "{{ MSFEpkg }}")'
+
+    {%- endif %}
 
 notify_V{{ stig_id }}-notfound:
   cmd.run:


### PR DESCRIPTION
'pkg.installed' fails if the specified package isn't in the yum
database. this commit checks first whether the package is available,
then installs it if it is. if it isn't available, it prints a warning.