### PR TITLE
Don't fail the state from non-actions

### DIFF
--- a/ash-linux/STIGbyID/cat2/files/V38520-helper.sh
+++ b/ash-linux/STIGbyID/cat2/files/V38520-helper.sh
@@ -20,7 +20,7 @@ CHKMOD=`rpm -qVf /etc/rsyslog.conf | grep '^..5'`
 if [ "${CHKMOD}" == "" ]
 then
    echo "WARN: rsyslog has not been configured"
-   exit 1
+   exit 0
 else
    echo "Info:  /etc/rsyslog.conf modified - rsyslog may have been configured"
    exit 0


### PR DESCRIPTION
Warn if rsyslog hasn't been configured, but exit 0.
Fixes #66