### PR TITLE
Don't fail the state due to non-actions

### DIFF
--- a/ash-linux/STIGbyID/cat2/V38521.sls
+++ b/ash-linux/STIGbyID/cat2/V38521.sls
@@ -54,7 +54,7 @@ notify_{{ stig_id }}-extLogging:
   {%- else %}
 notify_{{ stig_id }}-extLogging:
   cmd.run:
-    - name: 'printf "*********************************************************\n* WARNING: System does not appear to be configured to log\n*\tto an external host.\n*********************************************************\n" >&2 ; exit 1'
+    - name: 'printf "*********************************************************\n* WARNING: System does not appear to be configured to log\n*\to an external host.\n*********************************************************\n" >&2'
   {%- endif %}
 {%- else %}
 notify_{{ stig_id }}-extLogging:


### PR DESCRIPTION
Warn if rsyslog is unconfigured, but exit 0.
Fixes #67