### PR TITLE
Use 'onlyif' test to check if pam module in pam file

### DIFF
--- a/ash-linux/STIGbyID/cat2/V51875.sls
+++ b/ash-linux/STIGbyID/cat2/V51875.sls
@@ -41,8 +41,8 @@ add_V{{ stig_id }}-{{ module }}:
     - name: {{ file }}
     - pattern: '^(?P<srctok>session[ \t]*.*pam_limits.so.*$)'
     - repl: '\g<srctok>\n{{ rule }}'
-    - unless:
-      - 'grep -E -e "{{ module }}" {{ file }}'
+    - onlyif:
+      - 'test $(grep -c -E -e "{{ module }}" {{ file }}) -eq 0'
 
 notify_V{{ stig_id }}-{{ module }}:
   cmd.run:


### PR DESCRIPTION
The 'unless' test executes with any non-zero execute, which includes
when the file doesn't yet exist (even though it will be created by the
state). This cause test=True runs to throw a spurious failure. The
'onlyif' test reverses the logic and so doesn't have the same issue.
Fixes #78