### PR TITLE
Add dedicated 'stig' and 'scap' baseline states

### DIFF
--- a/ash-linux/scap.sls
+++ b/ash-linux/scap.sls
@@ -1,0 +1,2 @@
+include:
+  - ash-linux.SCAPonly

--- a/ash-linux/stig.sls
+++ b/ash-linux/stig.sls
@@ -1,0 +1,2 @@
+include:
+  - ash-linux.STIGbyID


### PR DESCRIPTION
Makes it easier to include a specific baseline.