### PR TITLE
Test if there are any packages to upgrade

### DIFF
--- a/ash-linux/STIGbyID/cat2/V38481-fix.sls
+++ b/ash-linux/STIGbyID/cat2/V38481-fix.sls
@@ -20,10 +20,11 @@ include:
 # Get list of RPMs that need to be updated
 {%- set updatePairs = salt['pkg.list_upgrades']('name') %}
 
+{%- if updatePairs %}
+
 remediate_V38481-updateRPMs:
   pkg:
     - latest
-    - pkgs:
-{%- for pkgName in updatePairs %}
-      - {{ pkgName }}
-{%- endfor %}
+    - pkgs: {{ updatePairs.keys() }}
+
+{%- endif %}


### PR DESCRIPTION
If there aren't any packages to upgrade, then 'updatePairs' is an empty
dict, which cause a yaml error as the state is incomplete.
Also, instead of looping over the updatePairs dict to create the package
list, just print a list of the keys, using '{{ updatePairs.keys() }}'.
Fixes #81